### PR TITLE
Update openlayers links

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,8 @@
 <html>
 	<head>
 		<title>MVT OL Debug</title>
-		<link rel="stylesheet" href="http://openlayers.org/en/v3.18.2/css/ol.css" type="text/css">
-		<script src="http://openlayers.org/en/v3.18.2/build/ol-debug.js"></script>
-
+		<script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
+		<link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
 		<style>
 			*{padding:0;margin:0;}
 			body{font-family:Verdana,sans-serif;}


### PR DESCRIPTION
Links to `openlayers version 3.18.2` are dead and broken.